### PR TITLE
Allow underscores in param names

### DIFF
--- a/railroad.html
+++ b/railroad.html
@@ -106,16 +106,16 @@ svg.railroad-diagram rect {
 </div>
 <h1><code>explicitReturn</code></h1>
 <div>
-<svg class="railroad-diagram" width="825" height="152" viewBox="0 0 825 152">
+<svg class="railroad-diagram" width="545" height="122" viewBox="0 0 545 122">
 <g transform="translate(.5 .5)">
 <path d="M 20 21 v 20 m 10 -20 v 20 m -10 -10 h 20.5"></path>
 <g>
 <path d="M40 31h0"></path>
-<path d="M784 31h0"></path>
+<path d="M504 31h0"></path>
 <path d="M40 31h20"></path>
 <g>
 <path d="M60 31h0"></path>
-<path d="M764 31h0"></path>
+<path d="M484 31h0"></path>
 <path d="M60 31h10"></path>
 <g>
 <path d="M70 31h0"></path>
@@ -143,41 +143,17 @@ svg.railroad-diagram rect {
 <path d="M388 31h10"></path>
 <g>
 <path d="M398 31h0"></path>
-<path d="M434 31h0"></path>
-<rect x="398" y="20" width="36" height="22"></rect>
-<text x="416" y="35">&#95;&#95;</text>
+<path d="M474 31h0"></path>
+<rect x="398" y="20" width="76" height="22"></rect>
+<text x="436" y="35">R&#95;CURLY</text>
 </g>
-<path d="M434 31h10"></path>
-<path d="M444 31h10"></path>
-<g>
-<path d="M454 31h0"></path>
-<path d="M522 31h0"></path>
-<rect x="454" y="20" width="68" height="22"></rect>
-<text x="488" y="35">RETURN</text>
+<path d="M474 31h10"></path>
 </g>
-<path d="M522 31h10"></path>
-<path d="M532 31h10"></path>
-<g>
-<path d="M542 31h0"></path>
-<path d="M658 31h0"></path>
-<rect x="542" y="20" width="116" height="22"></rect>
-<text x="600" y="35">returnValues</text>
-</g>
-<path d="M658 31h10"></path>
-<path d="M668 31h10"></path>
-<g>
-<path d="M678 31h0"></path>
-<path d="M754 31h0"></path>
-<rect x="678" y="20" width="76" height="22"></rect>
-<text x="716" y="35">R&#95;CURLY</text>
-</g>
-<path d="M754 31h10"></path>
-</g>
-<path d="M764 31h20"></path>
+<path d="M484 31h20"></path>
 <path d="M40 31a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path>
 <g>
 <path d="M60 61h60"></path>
-<path d="M704 61h60"></path>
+<path d="M424 61h60"></path>
 <path d="M120 61h10"></path>
 <g>
 <path d="M130 61h0"></path>
@@ -197,41 +173,17 @@ svg.railroad-diagram rect {
 <path d="M328 61h10"></path>
 <g>
 <path d="M338 61h0"></path>
-<path d="M374 61h0"></path>
-<rect x="338" y="50" width="36" height="22"></rect>
-<text x="356" y="65">&#95;&#95;</text>
+<path d="M414 61h0"></path>
+<rect x="338" y="50" width="76" height="22"></rect>
+<text x="376" y="65">R&#95;CURLY</text>
 </g>
-<path d="M374 61h10"></path>
-<path d="M384 61h10"></path>
-<g>
-<path d="M394 61h0"></path>
-<path d="M462 61h0"></path>
-<rect x="394" y="50" width="68" height="22"></rect>
-<text x="428" y="65">RETURN</text>
+<path d="M414 61h10"></path>
 </g>
-<path d="M462 61h10"></path>
-<path d="M472 61h10"></path>
-<g>
-<path d="M482 61h0"></path>
-<path d="M598 61h0"></path>
-<rect x="482" y="50" width="116" height="22"></rect>
-<text x="540" y="65">returnValues</text>
-</g>
-<path d="M598 61h10"></path>
-<path d="M608 61h10"></path>
-<g>
-<path d="M618 61h0"></path>
-<path d="M694 61h0"></path>
-<rect x="618" y="50" width="76" height="22"></rect>
-<text x="656" y="65">R&#95;CURLY</text>
-</g>
-<path d="M694 61h10"></path>
-</g>
-<path d="M764 61a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path>
+<path d="M484 61a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path>
 <path d="M40 31a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path>
 <g>
 <path d="M60 91h56"></path>
-<path d="M708 91h56"></path>
+<path d="M428 91h56"></path>
 <path d="M116 91h10"></path>
 <g>
 <path d="M126 91h0"></path>
@@ -251,113 +203,89 @@ svg.railroad-diagram rect {
 <path d="M332 91h10"></path>
 <g>
 <path d="M342 91h0"></path>
-<path d="M378 91h0"></path>
-<rect x="342" y="80" width="36" height="22"></rect>
-<text x="360" y="95">&#95;&#95;</text>
+<path d="M418 91h0"></path>
+<rect x="342" y="80" width="76" height="22"></rect>
+<text x="380" y="95">R&#95;CURLY</text>
 </g>
-<path d="M378 91h10"></path>
-<path d="M388 91h10"></path>
-<g>
-<path d="M398 91h0"></path>
-<path d="M466 91h0"></path>
-<rect x="398" y="80" width="68" height="22"></rect>
-<text x="432" y="95">RETURN</text>
+<path d="M418 91h10"></path>
 </g>
-<path d="M466 91h10"></path>
-<path d="M476 91h10"></path>
-<g>
-<path d="M486 91h0"></path>
-<path d="M602 91h0"></path>
-<rect x="486" y="80" width="116" height="22"></rect>
-<text x="544" y="95">returnValues</text>
+<path d="M484 91a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path>
 </g>
-<path d="M602 91h10"></path>
-<path d="M612 91h10"></path>
-<g>
-<path d="M622 91h0"></path>
-<path d="M698 91h0"></path>
-<rect x="622" y="80" width="76" height="22"></rect>
-<text x="660" y="95">R&#95;CURLY</text>
-</g>
-<path d="M698 91h10"></path>
-</g>
-<path d="M764 91a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path>
-<path d="M40 31a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path>
-<g>
-<path d="M60 121h120"></path>
-<path d="M644 121h120"></path>
-<path d="M180 121h10"></path>
-<g>
-<path d="M190 121h0"></path>
-<path d="M266 121h0"></path>
-<rect x="190" y="110" width="76" height="22"></rect>
-<text x="228" y="125">L&#95;CURLY</text>
-</g>
-<path d="M266 121h10"></path>
-<path d="M276 121h10"></path>
-<g>
-<path d="M286 121h0"></path>
-<path d="M314 121h0"></path>
-<rect x="286" y="110" width="28" height="22"></rect>
-<text x="300" y="125">&#95;</text>
-</g>
-<path d="M314 121h10"></path>
-<path d="M324 121h10"></path>
-<g>
-<path d="M334 121h0"></path>
-<path d="M402 121h0"></path>
-<rect x="334" y="110" width="68" height="22"></rect>
-<text x="368" y="125">RETURN</text>
-</g>
-<path d="M402 121h10"></path>
-<path d="M412 121h10"></path>
-<g>
-<path d="M422 121h0"></path>
-<path d="M538 121h0"></path>
-<rect x="422" y="110" width="116" height="22"></rect>
-<text x="480" y="125">returnValues</text>
-</g>
-<path d="M538 121h10"></path>
-<path d="M548 121h10"></path>
-<g>
-<path d="M558 121h0"></path>
-<path d="M634 121h0"></path>
-<rect x="558" y="110" width="76" height="22"></rect>
-<text x="596" y="125">R&#95;CURLY</text>
-</g>
-<path d="M634 121h10"></path>
-</g>
-<path d="M764 121a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path>
-</g>
-<path d="M 784 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+<path d="M 504 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
 </g>
 </svg>
 
 </div>
 <h1><code>implicitReturn</code></h1>
 <div>
-<svg class="railroad-diagram" width="249" height="62" viewBox="0 0 249 62">
+<svg class="railroad-diagram" width="617" height="92" viewBox="0 0 617 92">
 <g transform="translate(.5 .5)">
 <path d="M 20 21 v 20 m 10 -20 v 20 m -10 -10 h 20.5"></path>
 <g>
 <path d="M40 31h0"></path>
-<path d="M208 31h0"></path>
+<path d="M576 31h0"></path>
 <path d="M40 31h20"></path>
 <g>
-<path d="M60 31h0"></path>
-<path d="M188 31h0"></path>
-<path d="M60 31h10"></path>
+<path d="M60 31h188"></path>
+<path d="M368 31h188"></path>
+<path d="M248 31h10"></path>
 <g>
-<path d="M70 31h0"></path>
-<path d="M178 31h0"></path>
-<rect x="70" y="20" width="108" height="22"></rect>
-<text x="124" y="35">returnValue</text>
+<path d="M258 31h0"></path>
+<path d="M358 31h0"></path>
+<rect x="258" y="20" width="100" height="22"></rect>
+<text x="308" y="35">singleLine</text>
 </g>
-<path d="M178 31h10"></path>
+<path d="M358 31h10"></path>
 </g>
-<path d="M188 31h20"></path>
+<path d="M556 31h20"></path>
+<path d="M40 31a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 61h0"></path>
+<path d="M556 61h0"></path>
+<path d="M60 61h10"></path>
+<g>
+<path d="M70 61h0"></path>
+<path d="M146 61h0"></path>
+<rect x="70" y="50" width="76" height="22"></rect>
+<text x="108" y="65">L&#95;PAREN</text>
 </g>
-<path d="M 208 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+<path d="M146 61h10"></path>
+<path d="M156 61h10"></path>
+<g>
+<path d="M166 61h0"></path>
+<path d="M242 61h0"></path>
+<rect x="166" y="50" width="76" height="22"></rect>
+<text x="204" y="65">L&#95;CURLY</text>
+</g>
+<path d="M242 61h10"></path>
+<path d="M252 61h10"></path>
+<g>
+<path d="M262 61h0"></path>
+<path d="M354 61h0"></path>
+<rect x="262" y="50" width="92" height="22"></rect>
+<text x="308" y="65">multiLine</text>
+</g>
+<path d="M354 61h10"></path>
+<path d="M364 61h10"></path>
+<g>
+<path d="M374 61h0"></path>
+<path d="M450 61h0"></path>
+<rect x="374" y="50" width="76" height="22"></rect>
+<text x="412" y="65">R&#95;CURLY</text>
+</g>
+<path d="M450 61h10"></path>
+<path d="M460 61h10"></path>
+<g>
+<path d="M470 61h0"></path>
+<path d="M546 61h0"></path>
+<rect x="470" y="50" width="76" height="22"></rect>
+<text x="508" y="65">R&#95;PAREN</text>
+</g>
+<path d="M546 61h10"></path>
+</g>
+<path d="M556 61a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path>
+</g>
+<path d="M 576 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
 </g>
 </svg>
 
@@ -1406,16 +1334,16 @@ svg.railroad-diagram rect {
 </div>
 <h1><code>chars</code></h1>
 <div>
-<svg class="railroad-diagram" width="425" height="81" viewBox="0 0 425 81">
+<svg class="railroad-diagram" width="433" height="81" viewBox="0 0 433 81">
 <g transform="translate(.5 .5)">
 <path d="M 20 31 v 20 m 10 -20 v 20 m -10 -10 h 20.5"></path>
 <g>
 <path d="M40 41h0"></path>
-<path d="M384 41h0"></path>
+<path d="M392 41h0"></path>
 <path d="M40 41h20"></path>
 <g>
 <path d="M60 41h0"></path>
-<path d="M364 41h0"></path>
+<path d="M372 41h0"></path>
 <path d="M60 41h10"></path>
 <g>
 <path d="M70 41h0"></path>
@@ -1426,43 +1354,43 @@ svg.railroad-diagram rect {
 <path d="M170 41h10"></path>
 <g>
 <path d="M180 41h0"></path>
-<path d="M364 41h0"></path>
+<path d="M372 41h0"></path>
 <path d="M180 41a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path>
 <g>
-<path d="M200 21h144"></path>
+<path d="M200 21h152"></path>
 </g>
-<path d="M344 21a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path>
+<path d="M352 21a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path>
 <path d="M180 41h20"></path>
 <g>
 <path d="M200 41h0"></path>
-<path d="M344 41h0"></path>
+<path d="M352 41h0"></path>
 <path d="M200 41h10"></path>
 <g>
 <path d="M210 41h0"></path>
-<path d="M334 41h0"></path>
-<rect x="210" y="30" width="124" height="22" rx="10" ry="10"></rect>
-<text x="272" y="45">/&#91;a-zA-Z0-9&#93;/</text>
+<path d="M342 41h0"></path>
+<rect x="210" y="30" width="132" height="22" rx="10" ry="10"></rect>
+<text x="276" y="45">/&#91;&#95;a-zA-Z0-9&#93;/</text>
 </g>
-<path d="M334 41h10"></path>
+<path d="M342 41h10"></path>
 <path d="M210 41a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path>
 <g>
-<path d="M210 61h124"></path>
+<path d="M210 61h132"></path>
 </g>
-<path d="M334 61a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path>
+<path d="M342 61a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path>
 </g>
-<path d="M344 41h20"></path>
+<path d="M352 41h20"></path>
 </g>
 </g>
-<path d="M364 41h20"></path>
+<path d="M372 41h20"></path>
 </g>
-<path d="M 384 41 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+<path d="M 392 41 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
 </g>
 </svg>
 
 </div>
 <h1><code>multiLine</code></h1>
 <div>
-<svg class="railroad-diagram" width="449" height="122" viewBox="0 0 449 122">
+<svg class="railroad-diagram" width="449" height="152" viewBox="0 0 449 152">
 <g transform="translate(.5 .5)">
 <path d="M 20 21 v 20 m 10 -20 v 20 m -10 -10 h 20.5"></path>
 <g>
@@ -1522,18 +1450,40 @@ svg.railroad-diagram rect {
 <path d="M388 61a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path>
 <path d="M40 31a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path>
 <g>
-<path d="M60 91h116"></path>
-<path d="M272 91h116"></path>
-<path d="M176 91h10"></path>
+<path d="M60 91h56"></path>
+<path d="M332 91h56"></path>
+<path d="M116 91h10"></path>
 <g>
-<path d="M186 91h0"></path>
-<path d="M262 91h0"></path>
-<rect x="186" y="80" width="76" height="22"></rect>
-<text x="224" y="95">newLine</text>
+<path d="M126 91h0"></path>
+<path d="M202 91h0"></path>
+<rect x="126" y="80" width="76" height="22"></rect>
+<text x="164" y="95">newLine</text>
 </g>
-<path d="M262 91h10"></path>
+<path d="M202 91h10"></path>
+<path d="M212 91h10"></path>
+<g>
+<path d="M222 91h0"></path>
+<path d="M322 91h0"></path>
+<rect x="222" y="80" width="100" height="22"></rect>
+<text x="272" y="95">singleLine</text>
+</g>
+<path d="M322 91h10"></path>
 </g>
 <path d="M388 91a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path>
+<path d="M40 31a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 121h116"></path>
+<path d="M272 121h116"></path>
+<path d="M176 121h10"></path>
+<g>
+<path d="M186 121h0"></path>
+<path d="M262 121h0"></path>
+<rect x="186" y="110" width="76" height="22"></rect>
+<text x="224" y="125">newLine</text>
+</g>
+<path d="M262 121h10"></path>
+</g>
+<path d="M388 121a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path>
 </g>
 <path d="M 408 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
 </g>

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -50,7 +50,7 @@ let ParserRules = [
     {"name": "sstrchar", "symbols": [{"literal":"\\"}, "strescape"], "postprocess": function(d) { return JSON.parse("\""+d.join("")+"\""); }},
     {"name": "sstrchar$string$1", "symbols": [{"literal":"\\"}, {"literal":"'"}], "postprocess": function joiner(d) {return d.join('');}},
     {"name": "sstrchar", "symbols": ["sstrchar$string$1"], "postprocess": function(d) {return "'"; }},
-    {"name": "strescape", "symbols": [/["\\\/bfnrt]/], "postprocess": id},
+    {"name": "strescape", "symbols": [/["\\/bfnrt]/], "postprocess": id},
     {"name": "strescape", "symbols": [{"literal":"u"}, /[a-fA-F0-9]/, /[a-fA-F0-9]/, /[a-fA-F0-9]/, /[a-fA-F0-9]/], "postprocess": 
         function(d) {
             return d.join("");
@@ -193,7 +193,7 @@ let ParserRules = [
     {"name": "number", "symbols": ["_", "decimal"], "postprocess": ([, value]) => ({type: 'number', value})},
     {"name": "token", "symbols": ["_", "chars"], "postprocess": ([, value]) => ({type: 'token', value})},
     {"name": "chars$ebnf$1", "symbols": []},
-    {"name": "chars$ebnf$1", "symbols": ["chars$ebnf$1", /[a-zA-Z0-9]/], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
+    {"name": "chars$ebnf$1", "symbols": ["chars$ebnf$1", /[_a-zA-Z0-9]/], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
     {"name": "chars", "symbols": [/[a-zA-Z]/, "chars$ebnf$1"], "postprocess": ([value, rest]) => `${value}${rest.join('')}`},
     {"name": "multiLine", "symbols": ["newLine", "singleLine", "multiLine"], "postprocess": ([, hit, rest], _ , reject) => rest ? [hit, rest].join('\n').trim() : reject},
     {"name": "multiLine", "symbols": ["newLine", "multiLine"], "postprocess": ([hit, rest]) => [hit, rest].join('\n').trim()},

--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -101,7 +101,7 @@ number -> _ decimal {% ([, value]) => ({type: 'number', value}) %}
 
 token -> _ chars {% ([, value]) => ({type: 'token', value}) %}
 
-chars -> [a-zA-Z] [a-zA-Z0-9]:* {% ([value, rest]) => `${value}${rest.join('')}` %}
+chars -> [a-zA-Z] [_a-zA-Z0-9]:* {% ([value, rest]) => `${value}${rest.join('')}` %}
 
 multiLine -> newLine singleLine multiLine {% ([, hit, rest], _ , reject) => rest ? [hit, rest].join('\n').trim() : reject %}
     | newLine multiLine {% ([hit, rest]) => [hit, rest].join('\n').trim() %} # щ（ﾟДﾟщ）

--- a/src/grammar.test.js
+++ b/src/grammar.test.js
@@ -34,6 +34,22 @@ describe('lambda-parser', () => {
             ])
         });
 
+        test('support tokens with underscores in their names', () => {
+            expect(parseLambda('x_1 => "foo"')).toEqual([
+                {
+                    type: 'lambda',
+                    variant: 'implicit',
+                    parameters: {
+                        type: 'token',
+                        value: 'x_1'
+                    },
+                    body: {
+                        returnValues: []
+                    }
+                }
+            ])
+        });
+
         test('does not support tokens with numbers first in their names', () => {
             expect(() => parseLambda('1x => "foo"')).toThrow('Syntax error at line 1 col 1:');
         });


### PR DESCRIPTION
We should support underscores in names. It seems åäö should also be supported from this [documentation](https://neo4j.com/docs/cypher-manual/current/syntax/naming/).

I am guess this would need a new release as well? 