### PR TITLE
Allow names starting with underscore as well

### DIFF
--- a/railroad.html
+++ b/railroad.html
@@ -1334,56 +1334,56 @@ svg.railroad-diagram rect {
 </div>
 <h1><code>chars</code></h1>
 <div>
-<svg class="railroad-diagram" width="433" height="81" viewBox="0 0 433 81">
+<svg class="railroad-diagram" width="441" height="81" viewBox="0 0 441 81">
 <g transform="translate(.5 .5)">
 <path d="M 20 31 v 20 m 10 -20 v 20 m -10 -10 h 20.5"></path>
 <g>
 <path d="M40 41h0"></path>
-<path d="M392 41h0"></path>
+<path d="M400 41h0"></path>
 <path d="M40 41h20"></path>
 <g>
 <path d="M60 41h0"></path>
-<path d="M372 41h0"></path>
+<path d="M380 41h0"></path>
 <path d="M60 41h10"></path>
 <g>
 <path d="M70 41h0"></path>
-<path d="M170 41h0"></path>
-<rect x="70" y="30" width="100" height="22" rx="10" ry="10"></rect>
-<text x="120" y="45">/&#91;a-zA-Z&#93;/</text>
+<path d="M178 41h0"></path>
+<rect x="70" y="30" width="108" height="22" rx="10" ry="10"></rect>
+<text x="124" y="45">/&#91;&#95;a-zA-Z&#93;/</text>
 </g>
-<path d="M170 41h10"></path>
+<path d="M178 41h10"></path>
 <g>
-<path d="M180 41h0"></path>
-<path d="M372 41h0"></path>
-<path d="M180 41a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path>
+<path d="M188 41h0"></path>
+<path d="M380 41h0"></path>
+<path d="M188 41a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path>
 <g>
-<path d="M200 21h152"></path>
+<path d="M208 21h152"></path>
 </g>
-<path d="M352 21a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path>
-<path d="M180 41h20"></path>
+<path d="M360 21a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path>
+<path d="M188 41h20"></path>
 <g>
-<path d="M200 41h0"></path>
-<path d="M352 41h0"></path>
-<path d="M200 41h10"></path>
+<path d="M208 41h0"></path>
+<path d="M360 41h0"></path>
+<path d="M208 41h10"></path>
 <g>
-<path d="M210 41h0"></path>
-<path d="M342 41h0"></path>
-<rect x="210" y="30" width="132" height="22" rx="10" ry="10"></rect>
-<text x="276" y="45">/&#91;&#95;a-zA-Z0-9&#93;/</text>
+<path d="M218 41h0"></path>
+<path d="M350 41h0"></path>
+<rect x="218" y="30" width="132" height="22" rx="10" ry="10"></rect>
+<text x="284" y="45">/&#91;&#95;a-zA-Z0-9&#93;/</text>
 </g>
-<path d="M342 41h10"></path>
-<path d="M210 41a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path>
+<path d="M350 41h10"></path>
+<path d="M218 41a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path>
 <g>
-<path d="M210 61h132"></path>
+<path d="M218 61h132"></path>
 </g>
-<path d="M342 61a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path>
+<path d="M350 61a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path>
 </g>
-<path d="M352 41h20"></path>
+<path d="M360 41h20"></path>
 </g>
 </g>
-<path d="M372 41h20"></path>
+<path d="M380 41h20"></path>
 </g>
-<path d="M 392 41 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+<path d="M 400 41 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
 </g>
 </svg>
 

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -194,7 +194,7 @@ let ParserRules = [
     {"name": "token", "symbols": ["_", "chars"], "postprocess": ([, value]) => ({type: 'token', value})},
     {"name": "chars$ebnf$1", "symbols": []},
     {"name": "chars$ebnf$1", "symbols": ["chars$ebnf$1", /[_a-zA-Z0-9]/], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
-    {"name": "chars", "symbols": [/[a-zA-Z]/, "chars$ebnf$1"], "postprocess": ([value, rest]) => `${value}${rest.join('')}`},
+    {"name": "chars", "symbols": [/[_a-zA-Z]/, "chars$ebnf$1"], "postprocess": ([value, rest]) => `${value}${rest.join('')}`},
     {"name": "multiLine", "symbols": ["newLine", "singleLine", "multiLine"], "postprocess": ([, hit, rest], _ , reject) => rest ? [hit, rest].join('\n').trim() : reject},
     {"name": "multiLine", "symbols": ["newLine", "multiLine"], "postprocess": ([hit, rest]) => [hit, rest].join('\n').trim()},
     {"name": "multiLine", "symbols": ["newLine", "singleLine"], "postprocess": ([hit, rest]) => [hit, rest].join('\n').trim()},

--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -101,7 +101,7 @@ number -> _ decimal {% ([, value]) => ({type: 'number', value}) %}
 
 token -> _ chars {% ([, value]) => ({type: 'token', value}) %}
 
-chars -> [a-zA-Z] [_a-zA-Z0-9]:* {% ([value, rest]) => `${value}${rest.join('')}` %}
+chars -> [_a-zA-Z] [_a-zA-Z0-9]:* {% ([value, rest]) => `${value}${rest.join('')}` %}
 
 multiLine -> newLine singleLine multiLine {% ([, hit, rest], _ , reject) => rest ? [hit, rest].join('\n').trim() : reject %}
     | newLine multiLine {% ([hit, rest]) => [hit, rest].join('\n').trim() %} # щ（ﾟДﾟщ）

--- a/src/grammar.test.js
+++ b/src/grammar.test.js
@@ -50,6 +50,22 @@ describe('lambda-parser', () => {
             ])
         });
 
+        test('support token names starting with underscores', () => {
+            expect(parseLambda('_steve => "foo"')).toEqual([
+                {
+                    type: 'lambda',
+                    variant: 'implicit',
+                    parameters: {
+                        type: 'token',
+                        value: '_steve'
+                    },
+                    body: {
+                        returnValues: []
+                    }
+                }
+            ])
+        });
+
         test('does not support tokens with numbers first in their names', () => {
             expect(() => parseLambda('1x => "foo"')).toThrow('Syntax error at line 1 col 1:');
         });


### PR DESCRIPTION
I ran cypher shell and confirmed param names should be able to start with underscore as well, so it felt wrong not supporting it! :) 